### PR TITLE
Create FullStory Sentry SDK integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.env

--- a/public/index.html
+++ b/public/index.html
@@ -23,7 +23,7 @@
     <script>
       window['_fs_debug'] = false;
       window['_fs_host'] = 'fullstory.com';
-      window['_fs_org'] = 'your org id here';
+      window['_fs_org'] = '%REACT_APP_FULLSTORY_ORG%';
       window['_fs_namespace'] = 'FS';
       (function(m,n,e,t,l,o,g,y){
           if (e in m) {if(m.console && m.console.log) { m.console.log('FullStory namespace conflict. Please set window["_fs_namespace"].');} return;}

--- a/src/api/error.js
+++ b/src/api/error.js
@@ -1,41 +1,32 @@
 import * as Sentry from '@sentry/browser';
-import * as FullStory from './fullstory';
+
+import FullStoryIntegration from '../integrations/FullStoryIntegration';
 
 let didInit = false;
-const initSentry = (sentryKey, sentryProject) => {
+const initSentry = sentryDsn => {
   if (didInit) {
-    console.warn('initSentry has already been called once. Additional invocations are ignored.');
+    console.warn(
+      'initSentry has already been called once. Additional invocations are ignored.',
+    );
     return;
   }
   Sentry.init({
-    dsn: `https://${sentryKey}@sentry.io/${sentryProject}`,
-    beforeSend(event, hint) {
-      const error = hint.originalException;
-      event.extra = event.extra || {};
-
-      // getCurrentSessionURL isn't available until after the FullStory script is fully bootstrapped.
-      // If an error occurs before getCurrentSessionURL is ready, make a note in Sentry and move on.
-      // More on getCurrentSessionURL here: https://help.fullstory.com/develop-js/getcurrentsessionurl
-      event.extra.fullstory = FullStory.getCurrentSessionURL(true) || 'current session URL API not ready';
-
-      // FS.event is immediately ready even if FullStory isn't fully bootstrapped
-      FullStory.event('Application Error', {
-        name: error.name,
-        message: error.message,
-        fileName: error.fileName,
-        lineNumber: error.lineNumber,
-        stack: error.stack,
-        sentryEventId: hint.event_id,
-      });
-      
-      return event;
-    }
+    dsn: sentryDsn,
+    integrations: [
+      new FullStoryIntegration(
+        process.env.REACT_APP_SENTRY_ORG,
+        process.env.REACT_APP_SENTRY_PROJECT,
+      ),
+    ],
   });
   didInit = true;
 };
 
-const recordError = (error) => {
-  if (!didInit) throw Error('You must call initSentry once before calling recordError');
+const recordError = error => {
+  if (!didInit)
+    throw Error(
+      'You must call initSentry once before calling recordError',
+    );
   Sentry.captureException(error);
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import './index.css';
 import * as serviceWorker from './serviceWorker';
 import { initSentry } from './api/error';
 
-initSentry('<your Sentry key>', '<your Sentry project>');
+initSentry(process.env.REACT_APP_SENTRY_DSN);
 
 ReactDOM.render(
   <Provider store={store}>

--- a/src/integrations/FullStoryIntegration.js
+++ b/src/integrations/FullStoryIntegration.js
@@ -1,0 +1,43 @@
+import * as Sentry from '@sentry/browser';
+
+import * as FullStory from '../api/fullstory';
+
+class FullStoryIntegration {
+  constructor(sentryOrg, sentryProject) {
+    this.name = 'FullStoryIntegration';
+    this.sentryOrg = sentryOrg;
+    this.sentryProject = sentryProject;
+  }
+
+  setupOnce() {
+    Sentry.addGlobalEventProcessor((event, hint) => {
+      const self = Sentry.getCurrentHub().getIntegration(
+        FullStoryIntegration,
+      );
+      // Run the integration ONLY when it was installed on the current Hub
+      if (self) {
+        // getCurrentSessionURL isn't available until after the FullStory script is fully bootstrapped.
+        // If an error occurs before getCurrentSessionURL is ready, make a note in Sentry and move on.
+        // More on getCurrentSessionURL here: https://help.fullstory.com/develop-js/getcurrentsessionurl
+        event.contexts = {
+          ...event.contexts,
+          fullStory: {
+            url:
+              FullStory.getCurrentSessionURL(true) ||
+              'current session URL API not ready',
+          },
+        };
+
+        // FS.event is immediately ready even if FullStory isn't fully bootstrapped
+        FullStory.event('Sentry Error', {
+          sentryUrl: `https://sentry.io/organizations/${this.sentryOrg}/projects/${this.sentryProject}/events/${hint.event_id}/`,
+        });
+      }
+      return event;
+    });
+  }
+}
+
+FullStoryIntegration.id = 'FullStoryIntegration';
+
+export default FullStoryIntegration;

--- a/src/integrations/FullStoryIntegration.js
+++ b/src/integrations/FullStoryIntegration.js
@@ -2,6 +2,13 @@ import * as Sentry from '@sentry/browser';
 
 import * as FullStory from '../api/fullstory';
 
+/**
+ * The below class demonstrates how one could build a stand-alone FullStory-Sentry SDK integration.
+ * This integration creates a link from the Sentry Error to the FullStory replay.
+ * It also creates a link from the FullStory event to the Sentry error.
+ * Docs on Sentry SDK integrations are here: https://docs.sentry.io/platforms/javascript/advance-settings/#dealing-with-integrations
+ */
+
 class FullStoryIntegration {
   constructor(sentryOrg, sentryProject) {
     this.name = 'FullStoryIntegration';


### PR DESCRIPTION
This PR creates a FullStory Sentry SDK integration that could be split out into a stand-alone library. The integration does the following:

- Creates a link from the Sentry Error to the FullStory replay
- Creates a link from the FullStory event to the Sentry error

Note to initialize the integration, the user must pass in their Sentry organization and project slugs into the constructor.

This PR also utilizes environment variables when appropriate. Also, changes to using the Sentry DSN as a single variable.